### PR TITLE
Improve configuration env parsing and TLS defaults

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"strings"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -24,8 +26,9 @@ type Config struct {
 }
 
 func Load() (*Config, error) {
-	viper.AutomaticEnv()
 	viper.SetEnvPrefix("ECHO_APP")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
 
 	// Set default values
 	viper.SetDefault("message", "")

--- a/internal/utils/cert.go
+++ b/internal/utils/cert.go
@@ -8,12 +8,13 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"net"
 	"time"
 )
 
 // GenerateSelfSignedCert generates a self-signed certificate
 func GenerateSelfSignedCert() (tls.Certificate, error) {
-	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return tls.Certificate{}, err
 	}
@@ -27,6 +28,8 @@ func GenerateSelfSignedCert() (tls.Certificate, error) {
 		NotAfter:    time.Now().Add(10 * 365 * 24 * time.Hour),
 		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:    []string{"localhost"},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)


### PR DESCRIPTION
## Summary
- ensure environment variables with hyphenated keys map correctly by configuring viper's env key replacer before automatic binding
- speed up self-signed certificate generation and add localhost SAN coverage for TLS endpoints

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f53844cd7c832ea9bac138956e3304