### PR TITLE
ci: remove Trivy vulnerability scanner from CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,23 +178,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: 'fs'
-          scan-ref: '.'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH,MEDIUM'
-          exit-code: '0'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
-        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        continue-on-error: true
-        with:
-          sarif_file: 'trivy-results.sarif'
-
       - name: Run gosec security scanner
         uses: securego/gosec@master
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -28,7 +28,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      security-events: write
       attestations: write
       id-token: write
     steps:
@@ -95,20 +94,6 @@ jobs:
           image: ${{ steps.first-tag.outputs.tag }}
           format: spdx-json
           output-file: sbom.spdx.json
-
-      - name: Scan image with Trivy
-        if: github.event_name != 'pull_request' && steps.build.outcome == 'success'
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ steps.first-tag.outputs.tag }}
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-
-      - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v4
-        if: github.event_name != 'pull_request' && steps.build.outcome == 'success'
-        with:
-          sarif_file: 'trivy-results.sarif'
 
       - name: Test Docker image
         if: github.event_name != 'pull_request' && steps.build.outcome == 'success'


### PR DESCRIPTION
Remove Trivy scan steps from both CI and Docker Build workflows:
- Remove filesystem scan and SARIF upload from CI security job
- Remove container image scan and SARIF upload from Docker workflow
- Remove unused security-events permission from Docker workflow

The gosec security scanner remains in the CI security job.