### PR TITLE
chore: ignore .claude/ local agent settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage.*
 # IDE and editor files
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 *~


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` to keep per-machine Claude Code CLI state out of the repository.
- The directory holds `settings.local.json` and ephemeral worktrees — purely local artifacts.

## Test plan
- [x] Verify `.gitignore` change applies cleanly (no tracked `.claude/` files to remove).