### PR TITLE
Add external readiness probe and integrate health/readiness endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,302 @@
+# Agent Instructions for echo-app
+
+This document contains instructions for AI coding assistants working on the echo-app repository.
+
+## Project Overview
+
+echo-app is a multi-protocol echo server written in Go that supports:
+- HTTP/HTTPS (with TLS)
+- TCP
+- gRPC
+- QUIC (HTTP/3)
+- Prometheus metrics
+- Health and readiness endpoints
+
+The application is designed for debugging, testing, and demonstrating various network protocols.
+
+## Technology Stack
+
+- **Language**: Go 1.25+
+- **Build Tool**: Go modules
+- **Testing**: Go standard testing, testify/assert
+- **Linting**: golangci-lint
+- **CI/CD**: GitHub Actions
+- **Containerization**: Docker
+- **Metrics**: Prometheus
+- **Protocols**: HTTP/1.1, HTTP/2, HTTP/3 (QUIC), TCP, gRPC
+
+## Development Workflow
+
+### Code Quality Standards
+
+1. **Testing Requirements**
+   - All new features must include tests
+   - Maintain or improve code coverage (current target: >50%)
+   - All tests must pass with the race detector: `go test -race ./...`
+   - Tests must be idempotent and avoid port conflicts
+   - Use unique ports for each test server (18xxx, 19xxx, 13xxx ranges)
+
+2. **Linting**
+   - Code must pass `golangci-lint run --timeout 5m`
+   - All linters are enabled, including errcheck
+   - No unchecked error returns are allowed, even in tests
+   - Use `_ =` prefix to explicitly ignore errors when appropriate
+
+3. **Formatting**
+   - All code must be formatted with `gofmt`
+   - Struct fields must be properly aligned
+   - Run `gofmt -w .` before committing
+
+4. **Race Detection**
+   - Protect shared state with appropriate synchronization primitives
+   - Use `sync.Mutex` or `sync.RWMutex` for concurrent access
+   - All concurrent code must pass `go test -race ./...`
+
+### File Organization
+
+```
+.
+├── cmd/echo-app/          # Main application entry point
+├── internal/
+│   ├── config/            # Configuration management
+│   ├── handlers/          # Protocol handlers (HTTP, TCP, gRPC, QUIC)
+│   ├── server/            # Server implementations
+│   └── utils/             # Utility functions (cert generation, etc.)
+├── proto/                 # Protocol buffer definitions
+├── Dockerfile             # Container image definition
+├── Makefile              # Build and test targets
+└── README.md             # User documentation
+```
+
+### Testing Guidelines
+
+1. **Test File Naming**: `*_test.go` in the same package
+2. **Test Ports**: Use unique ports to avoid conflicts
+   - HTTP tests: 18080-18099
+   - TCP tests: 19090-19099
+   - Metrics tests: 13000-13009
+3. **Concurrency**: Use `sync.WaitGroup` and channels for synchronization
+4. **Cleanup**: Always use `defer` for cleanup (cancel contexts, close connections)
+5. **Error Handling**: All error returns must be checked or explicitly ignored with `_ =`
+
+### Common Patterns
+
+#### Starting Servers in Tests
+```go
+go func() { _ = server.Start(ctx) }()  // Explicitly ignore error
+time.Sleep(100 * time.Millisecond)     // Wait for server to start
+```
+
+#### Shutting Down Servers
+```go
+shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer shutdownCancel()
+_ = server.Shutdown(shutdownCtx)  // Or use assert.NoError() if critical
+```
+
+#### Error Handling in Tests
+```go
+// For critical operations
+require.NoError(t, err)
+
+// For explicitly ignored errors
+_ = conn.Close()
+_, _ = io.Copy(io.Discard, resp.Body)
+
+// For deferred cleanup
+defer func() { _ = resp.Body.Close() }()
+```
+
+## Git Commit Guidelines
+
+### Commit Message Format
+
+Follow the Conventional Commits specification:
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**Types:**
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation changes
+- `test`: Adding or updating tests
+- `refactor`: Code refactoring
+- `perf`: Performance improvements
+- `chore`: Maintenance tasks
+- `ci`: CI/CD changes
+- `deps`: Dependency updates
+
+**Examples:**
+```
+feat: add configurable request body size limit
+
+Add configurable maximum request body size limit to prevent resource
+exhaustion attacks via large request payloads. Default is 10MB.
+
+Configuration:
+- Environment variable: ECHO_APP_MAX_REQUEST_SIZE
+- Command-line flag: --max-request-size
+- Default: 10485760 bytes (10MB)
+```
+
+```
+fix: resolve data race conditions in TCP server
+
+Fix critical data race conditions detected by the race detector in the
+TCP server implementation. Add proper synchronization for concurrent
+access to shared fields.
+
+Changes:
+- Add RWMutex to protect concurrent access to listener and ctx
+- Use mutex in Start() when setting listener and context
+- Use mutex in Shutdown() when accessing listener
+```
+
+### Commit Message Rules
+
+**IMPORTANT**:
+- **NEVER** mention AI, Codex, or similar in commit messages
+- **NEVER** add "Co-Authored-By: Codex" or similar footers
+- **NEVER** add "Generated with Codex" or similar notices
+- Write commit messages as if written by a human developer
+- Focus on the "why" and "what" of the change, not the "how"
+- Keep commits focused and atomic
+- Write clear, concise commit messages in imperative mood
+
+### Good Commit Messages
+```
+fix: add panic recovery to HTTP handler
+
+Add panic recovery mechanism to prevent crashes from unexpected panics.
+This ensures that a single malformed request cannot crash the entire
+HTTP/TLS listener.
+
+- Add defer recover() at the start of handler
+- Log panic details with context
+- Record panic as error metric
+- Return HTTP 500 to client on panic
+```
+
+### Bad Commit Messages (DO NOT USE)
+```
+fix: add panic recovery to HTTP handler
+
+🤖 Generated with [Codex](https://Codex.com/Codex)
+
+Co-Authored-By: Codex <noreply@anthropic.com>
+```
+
+## GitHub Actions CI
+
+The CI pipeline runs on every push and pull request:
+
+1. **Linting**: `golangci-lint run`
+2. **Formatting**: `gofmt -l .`
+3. **Tests**: `go test -race ./...`
+4. **Build**: `go build ./...`
+
+All checks must pass before merging.
+
+### Development Workflow Best Practices
+
+**Before committing code:**
+
+1. **Clear linter cache** to ensure fresh results matching CI behavior
+2. **Run all checks locally** using the same commands as CI
+3. **Verify all checks pass** before pushing commits
+
+**When making code changes:**
+
+1. **Search comprehensively** - Use grep/search to find all instances of patterns you're modifying
+2. **Fix systematically** - Address all occurrences at once, not incrementally
+3. **Test thoroughly** - Run tests with race detector after every significant change
+4. **Validate locally** - Ensure linter returns success (exit code 0) before committing
+
+This workflow prevents CI failures by catching issues locally before they reach the remote repository.
+
+## Security Considerations
+
+1. **Input Validation**: Validate all user inputs
+2. **Resource Limits**: Enforce connection limits, request size limits, timeouts
+3. **TLS**: Use strong TLS configurations, generate proper certificates
+4. **Panic Recovery**: Add panic recovery to all server handlers
+5. **Metrics**: Don't create unlimited time series (normalize endpoints)
+
+## Common Tasks
+
+### Adding a New Feature
+
+1. Create tests first (TDD approach)
+2. Implement the feature
+3. Ensure tests pass with race detector
+4. Run linter and fix all issues
+5. Update documentation if needed
+6. Commit with conventional commit message (no AI mentions)
+
+### Fixing a Bug
+
+1. Write a failing test that reproduces the bug
+2. Fix the bug
+3. Ensure test passes
+4. Run full test suite with race detector
+5. Commit with fix: prefix (no AI mentions)
+
+### Updating Dependencies
+
+1. Run `go get -u ./...` or update specific packages
+2. Run `go mod tidy`
+3. Run full test suite
+4. Check for breaking changes
+5. Commit with deps: prefix
+
+### Running Tests
+
+```bash
+# Run all tests
+go test ./...
+
+# Run with race detector
+go test -race ./...
+
+# Run with coverage
+go test -cover ./...
+
+# Run specific test
+go test -run TestHTTPServer_StartAndStop ./internal/server
+
+# Run linter
+golangci-lint run --timeout 5m
+
+# Format code
+gofmt -w .
+```
+
+## Configuration
+
+The application uses environment variables and command-line flags:
+
+- `ECHO_APP_MESSAGE`: Custom message to echo back
+- `ECHO_APP_NODE`: Node identifier
+- `ECHO_APP_HTTP_PORT`: HTTP port (default: 8080)
+- `ECHO_APP_TLS_PORT`: TLS port (default: 8443)
+- `ECHO_APP_TCP_PORT`: TCP port (default: 9090)
+- `ECHO_APP_GRPC_PORT`: gRPC port (default: 50051)
+- `ECHO_APP_QUIC_PORT`: QUIC port (default: 4433)
+- `ECHO_APP_METRICS_PORT`: Metrics port (default: 3000)
+- `ECHO_APP_MAX_REQUEST_SIZE`: Max request body size (default: 10MB)
+- `ECHO_APP_LOG_LEVEL`: Log level (debug, info, warn, error)
+
+## Additional Notes
+
+- The codebase uses the internal/ directory to prevent external imports
+- Protocol buffers are in proto/ and compiled to internal/handlers/
+- TLS certificates are auto-generated using self-signed certs
+- All servers support graceful shutdown with context cancellation
+- Connection limits are enforced to prevent resource exhaustion
+- Metrics follow Prometheus naming conventions

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ ARG VCS_REF
 # Set the working directory inside the container
 WORKDIR /app
 
+RUN apk add --no-cache ca-certificates
+
 # Copy go.mod to download dependencies
 COPY go.mod ./
 # Download dependencies
@@ -42,6 +44,7 @@ LABEL org.opencontainers.image.title="echo-app" \
 
 # Copy the compiled binary from the builder stage
 COPY --from=builder /main /main
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Set the binary as the entrypoint of the container
 ENTRYPOINT ["/main"]

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ test-integration: build-quick ## TEST: Run integration tests with all endpoints
 	fi; \
 	\
 	printf "$(BLUE)Testing health endpoint...$(NC)\n" | tee -a $(BUILD_DIR)/test-results.log; \
-	if [ "$$(curl -s http://localhost:3000/health)" = "OK" ]; then \
+	if [ "$$(curl -s http://localhost:3000/health)" = "healthy" ]; then \
 		printf "$(GREEN)✓ Health check passed$(NC)\n" | tee -a $(BUILD_DIR)/test-results.log; \
 	else \
 		printf "$(RED)✗ Health check failed$(NC)\n" | tee -a $(BUILD_DIR)/test-results.log; \
@@ -244,7 +244,7 @@ test-integration: build-quick ## TEST: Run integration tests with all endpoints
 	fi; \
 	\
 	printf "$(BLUE)Testing readiness endpoint...$(NC)\n" | tee -a $(BUILD_DIR)/test-results.log; \
-	if [ "$$(curl -s http://localhost:3000/ready)" = "Ready" ]; then \
+	if [ "$$(curl -s http://localhost:3000/ready)" = "ready" ]; then \
 		printf "$(GREEN)✓ Readiness check passed$(NC)\n" | tee -a $(BUILD_DIR)/test-results.log; \
 	else \
 		printf "$(RED)✗ Readiness check failed$(NC)\n" | tee -a $(BUILD_DIR)/test-results.log; \

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Configure the application using these environment variables:
 - `ECHO_APP_METRICS_PORT`: Port for the metrics server (default: `3000` TCP).
 - `ECHO_APP_LOG_LEVEL`: Logging level (`debug`, `info`, `warn`, `error`; default: `info`).
 - `ECHO_APP_MAX_REQUEST_SIZE`: Maximum request body size in bytes (default: `10485760` - 10MB).
-- `ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE`: Optional external readiness probe type: `none`, `http`, `tcp`, or `ping` (default: `none`).
+- `ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE`: Optional external readiness probe type: `none`, `http`, `tcp`, or `icmp` (default: `none`).
 - `ECHO_APP_EXTERNAL_READINESS_PROBE_TARGET`: External readiness target, such as `https://api.example.com/ready`, `db.example.com:5432`, or `10.0.0.10`.
 - `ECHO_APP_EXTERNAL_READINESS_PROBE_INTERVAL`: How often the background readiness controller checks the target (default: `10s`).
 - `ECHO_APP_EXTERNAL_READINESS_PROBE_TIMEOUT`: Per-check timeout before the app marks itself not ready (default: `2s`).
@@ -67,7 +67,7 @@ Usage of ./echo-app:
       --external-readiness-probe-timeout duration
                                      External readiness probe timeout (default 2s)
       --external-readiness-probe-type string
-                                     External readiness probe type: none, http, tcp, or ping (default "none")
+                                     External readiness probe type: none, http, tcp, or icmp (default "none")
       --grpc                         Enable gRPC server
       --grpc-port string             gRPC server port (default "50051")
       --http-port string             HTTP server port (default "8080")
@@ -303,11 +303,15 @@ ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE=tcp \
 ECHO_APP_EXTERNAL_READINESS_PROBE_TARGET=db.example.com:5432 \
 ./echo-app
 
-# Ping readiness dependency: require one successful ping within the timeout
-ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE=ping \
+# ICMP readiness dependency: require one successful echo reply within the timeout
+ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE=icmp \
 ECHO_APP_EXTERNAL_READINESS_PROBE_TARGET=10.0.0.10 \
 ./echo-app
 ```
+
+The ICMP probe runs in-process and does not require a `ping` binary in the
+container. It uses raw ICMP sockets, so container runtimes that drop
+`CAP_NET_RAW` must add that capability back for ICMP readiness probes.
 
 ### Unified Metrics
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,30 @@ Configure the application using these environment variables:
 - `ECHO_APP_METRICS_PORT`: Port for the metrics server (default: `3000` TCP).
 - `ECHO_APP_LOG_LEVEL`: Logging level (`debug`, `info`, `warn`, `error`; default: `info`).
 - `ECHO_APP_MAX_REQUEST_SIZE`: Maximum request body size in bytes (default: `10485760` - 10MB).
+- `ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE`: Optional external readiness probe type: `none`, `http`, `tcp`, or `ping` (default: `none`).
+- `ECHO_APP_EXTERNAL_READINESS_PROBE_TARGET`: External readiness target, such as `https://api.example.com/ready`, `db.example.com:5432`, or `10.0.0.10`.
+- `ECHO_APP_EXTERNAL_READINESS_PROBE_INTERVAL`: How often the background readiness controller checks the target (default: `10s`).
+- `ECHO_APP_EXTERNAL_READINESS_PROBE_TIMEOUT`: Per-check timeout before the app marks itself not ready (default: `2s`).
+- `ECHO_APP_EXTERNAL_READINESS_HTTP_METHOD`: HTTP method for external HTTP readiness probes (default: `GET`).
+- `ECHO_APP_EXTERNAL_READINESS_HTTP_EXPECTED_STATUS`: Expected HTTP status code for external HTTP readiness probes (default: `200`).
 
 ### Command-Line Flags
 Run `./echo-app --help` to see all available flags:
 
 ```bash
 Usage of ./echo-app:
+      --external-readiness-http-expected-status int
+                                     Expected HTTP status for external readiness HTTP probes (default 200)
+      --external-readiness-http-method string
+                                     HTTP method for external readiness HTTP probes (default "GET")
+      --external-readiness-probe-interval duration
+                                     External readiness probe interval (default 10s)
+      --external-readiness-probe-target string
+                                     External readiness probe target URL, host:port, or host/IP
+      --external-readiness-probe-timeout duration
+                                     External readiness probe timeout (default 2s)
+      --external-readiness-probe-type string
+                                     External readiness probe type: none, http, tcp, or ping (default "none")
       --grpc                         Enable gRPC server
       --grpc-port string             gRPC server port (default "50051")
       --http-port string             HTTP server port (default "8080")
@@ -255,16 +273,40 @@ grpcurl -plaintext -emit-defaults localhost:50051 echo.EchoService.Echo
 
 #### Health Checks
 ```bash
-# Health endpoint
+# Health endpoint (liveness): returns 200 only when the echo app process is healthy
 curl -s http://localhost:3000/health
-# Returns: OK
+# Returns: healthy
 
-# Readiness endpoint
+# Readiness endpoint: returns 200 only when the echo app is ready and any configured external readiness probe is passing
 curl -s http://localhost:3000/ready
-# Returns: Ready
+# Returns: ready
+
+# Kubernetes probes should use the dedicated metrics/admin listener (default port 3000), not the echo traffic listeners.
 
 # Prometheus metrics
 curl -s http://localhost:3000/metrics | grep echo_app
+```
+
+#### External Readiness Probe Examples
+The external readiness probe is optional. When enabled, the app keeps checking the configured target in the background and `/ready` returns `503` until the target succeeds within the configured timeout.
+
+```bash
+# HTTP readiness dependency: expect a 200 from the upstream readiness URL
+ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE=http \
+ECHO_APP_EXTERNAL_READINESS_PROBE_TARGET=https://upstream.example.com/ready \
+ECHO_APP_EXTERNAL_READINESS_PROBE_TIMEOUT=2s \
+ECHO_APP_EXTERNAL_READINESS_PROBE_INTERVAL=10s \
+./echo-app
+
+# TCP readiness dependency: require a connectable host:port
+ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE=tcp \
+ECHO_APP_EXTERNAL_READINESS_PROBE_TARGET=db.example.com:5432 \
+./echo-app
+
+# Ping readiness dependency: require one successful ping within the timeout
+ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE=ping \
+ECHO_APP_EXTERNAL_READINESS_PROBE_TARGET=10.0.0.10 \
+./echo-app
 ```
 
 ### Unified Metrics
@@ -301,6 +343,13 @@ data:
   ECHO_APP_GRPC: "true"
   ECHO_APP_TCP: "true"
   ECHO_APP_METRICS: "true"
+  # Optional: mark this pod not-ready when a required upstream stops responding.
+  ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE: "http"
+  ECHO_APP_EXTERNAL_READINESS_PROBE_TARGET: "https://upstream.example.com/ready"
+  ECHO_APP_EXTERNAL_READINESS_HTTP_METHOD: "GET"
+  ECHO_APP_EXTERNAL_READINESS_HTTP_EXPECTED_STATUS: "200"
+  ECHO_APP_EXTERNAL_READINESS_PROBE_TIMEOUT: "2s"
+  ECHO_APP_EXTERNAL_READINESS_PROBE_INTERVAL: "10s"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cmd/echo-app/main.go
+++ b/cmd/echo-app/main.go
@@ -36,7 +36,7 @@ func main() {
 	pflag.String("metrics-port", "3000", "Metrics server port")
 	pflag.String("log-level", "info", "Log level (debug, info, warn, error)")
 	pflag.Int64("max-request-size", 10485760, "Maximum request body size in bytes (default: 10MB)")
-	pflag.String("external-readiness-probe-type", "none", "External readiness probe type: none, http, tcp, or ping")
+	pflag.String("external-readiness-probe-type", "none", "External readiness probe type: none, http, tcp, or icmp")
 	pflag.String("external-readiness-probe-target", "", "External readiness probe target URL, host:port, or host/IP")
 	pflag.Duration("external-readiness-probe-interval", 10*time.Second, "External readiness probe interval")
 	pflag.Duration("external-readiness-probe-timeout", 2*time.Second, "External readiness probe timeout")
@@ -141,6 +141,7 @@ func validateConfig(cfg *config.Config) error {
 		return fmt.Errorf("invalid metrics port: %s", cfg.MetricsPort)
 	}
 	if cfg.ExternalReadinessProbe.Enabled() {
+		// Keep "ping" as a compatibility alias for the in-process ICMP probe.
 		switch cfg.ExternalReadinessProbe.Type {
 		case "http", "https", "tcp", "ping", "icmp":
 		default:

--- a/cmd/echo-app/main.go
+++ b/cmd/echo-app/main.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/PhilipSchmid/echo-app/internal/config"
+	"github.com/PhilipSchmid/echo-app/internal/health"
 	"github.com/PhilipSchmid/echo-app/internal/server"
 	"github.com/PhilipSchmid/echo-app/internal/utils"
 	"github.com/sirupsen/logrus"
@@ -35,6 +36,12 @@ func main() {
 	pflag.String("metrics-port", "3000", "Metrics server port")
 	pflag.String("log-level", "info", "Log level (debug, info, warn, error)")
 	pflag.Int64("max-request-size", 10485760, "Maximum request body size in bytes (default: 10MB)")
+	pflag.String("external-readiness-probe-type", "none", "External readiness probe type: none, http, tcp, or ping")
+	pflag.String("external-readiness-probe-target", "", "External readiness probe target URL, host:port, or host/IP")
+	pflag.Duration("external-readiness-probe-interval", 10*time.Second, "External readiness probe interval")
+	pflag.Duration("external-readiness-probe-timeout", 2*time.Second, "External readiness probe timeout")
+	pflag.String("external-readiness-http-method", "GET", "HTTP method for external readiness HTTP probes")
+	pflag.Int("external-readiness-http-expected-status", 200, "Expected HTTP status for external readiness HTTP probes")
 
 	// Parse the flags
 	pflag.Parse()
@@ -55,8 +62,11 @@ func main() {
 		logrus.Fatalf("Invalid configuration: %v", err)
 	}
 
+	// Create shared health/readiness checker
+	healthChecker := health.NewChecker(cfg.ExternalReadinessProbe)
+
 	// Create server manager
-	manager := server.NewManager(cfg)
+	manager := server.NewManager(cfg, healthChecker)
 
 	// Register servers based on configuration
 	// Always start HTTP server
@@ -75,7 +85,7 @@ func main() {
 		manager.RegisterServer(server.NewQUICServer(cfg))
 	}
 	if cfg.Metrics {
-		manager.RegisterServer(server.NewMetricsServer(cfg))
+		manager.RegisterServer(server.NewMetricsServer(cfg, healthChecker))
 	}
 
 	// Create context for server lifecycle
@@ -83,6 +93,8 @@ func main() {
 	defer cancel()
 
 	// Start all servers
+	healthChecker.Start(ctx)
+
 	if err := manager.Start(ctx); err != nil {
 		logrus.Errorf("Failed to start servers: %v", err)
 	}
@@ -127,6 +139,13 @@ func validateConfig(cfg *config.Config) error {
 	}
 	if cfg.Metrics && !utils.IsValidPort(cfg.MetricsPort) {
 		return fmt.Errorf("invalid metrics port: %s", cfg.MetricsPort)
+	}
+	if cfg.ExternalReadinessProbe.Enabled() {
+		switch cfg.ExternalReadinessProbe.Type {
+		case "http", "https", "tcp", "ping", "icmp":
+		default:
+			return fmt.Errorf("invalid external readiness probe type: %s", cfg.ExternalReadinessProbe.Type)
+		}
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 toolchain go1.25.1
 
 require (
+	github.com/prometheus-community/pro-bing v0.9.1
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	google.golang.org/grpc v1.81.1
@@ -16,6 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -32,6 +34,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus-community/pro-bing v0.9.1 h1:kpuAr6AU2oRtzGihJSUcetHtjc7ku7h6PxeuW9RVrQw=
+github.com/prometheus-community/pro-bing v0.9.1/go.mod h1:z79wYTxAOf6FpTng0QdIhZ3j/Nd5l3+gnFSCIT+SiSQ=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
@@ -94,6 +96,8 @@ golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
 golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,23 +14,24 @@ const (
 )
 
 type Config struct {
-	Message        string
-	Node           string
-	PrintHeaders   bool
-	TLS            bool
-	H2C            bool
-	TCP            bool
-	GRPC           bool
-	QUIC           bool
-	Metrics        bool
-	HTTPPort       string
-	TLSPort        string
-	TCPPort        string
-	GRPCPort       string
-	QUICPort       string
-	MetricsPort    string
-	LogLevel       logrus.Level
-	MaxRequestSize int64 // Maximum request body size in bytes
+	Message                string
+	Node                   string
+	PrintHeaders           bool
+	TLS                    bool
+	H2C                    bool
+	TCP                    bool
+	GRPC                   bool
+	QUIC                   bool
+	Metrics                bool
+	HTTPPort               string
+	TLSPort                string
+	TCPPort                string
+	GRPCPort               string
+	QUICPort               string
+	MetricsPort            string
+	LogLevel               logrus.Level
+	MaxRequestSize         int64 // Maximum request body size in bytes
+	ExternalReadinessProbe ExternalReadinessProbe
 }
 
 func Load() (*Config, error) {
@@ -56,6 +57,12 @@ func Load() (*Config, error) {
 	viper.SetDefault("metrics-port", "3000")
 	viper.SetDefault("log-level", "info")
 	viper.SetDefault("max-request-size", 10485760) // 10 MB default
+	viper.SetDefault("external-readiness-probe-type", "none")
+	viper.SetDefault("external-readiness-probe-target", "")
+	viper.SetDefault("external-readiness-probe-interval", "10s")
+	viper.SetDefault("external-readiness-probe-timeout", "2s")
+	viper.SetDefault("external-readiness-http-method", "GET")
+	viper.SetDefault("external-readiness-http-expected-status", 200)
 
 	// Load configuration from viper
 	cfg := &Config{
@@ -75,6 +82,14 @@ func Load() (*Config, error) {
 		QUICPort:       viper.GetString("quic-port"),
 		MetricsPort:    viper.GetString("metrics-port"),
 		MaxRequestSize: viper.GetInt64("max-request-size"),
+		ExternalReadinessProbe: ExternalReadinessProbe{
+			Type:               strings.ToLower(viper.GetString("external-readiness-probe-type")),
+			Target:             viper.GetString("external-readiness-probe-target"),
+			Interval:           viper.GetDuration("external-readiness-probe-interval"),
+			Timeout:            viper.GetDuration("external-readiness-probe-timeout"),
+			HTTPMethod:         strings.ToUpper(viper.GetString("external-readiness-http-method")),
+			HTTPExpectedStatus: viper.GetInt("external-readiness-http-expected-status"),
+		},
 	}
 
 	// Set log level
@@ -84,6 +99,19 @@ func Load() (*Config, error) {
 	}
 	cfg.LogLevel = lvl
 	logrus.SetLevel(cfg.LogLevel)
+
+	// Validate external readiness settings
+	if cfg.ExternalReadinessProbe.Enabled() {
+		if cfg.ExternalReadinessProbe.Interval <= 0 {
+			return nil, fmt.Errorf("external readiness probe interval must be greater than zero")
+		}
+		if cfg.ExternalReadinessProbe.Timeout <= 0 {
+			return nil, fmt.Errorf("external readiness probe timeout must be greater than zero")
+		}
+		if cfg.ExternalReadinessProbe.HTTPExpectedStatus < 100 || cfg.ExternalReadinessProbe.HTTPExpectedStatus > 599 {
+			return nil, fmt.Errorf("external readiness HTTP expected status must be between 100 and 599")
+		}
+	}
 
 	// Validate message length
 	if len(cfg.Message) > MaxMessageLength {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -338,4 +339,32 @@ func TestLoad_CombinedConfiguration(t *testing.T) {
 	assert.True(t, cfg.PrintHeaders)
 	assert.Equal(t, logrus.DebugLevel, cfg.LogLevel)
 	assert.Equal(t, int64(20971520), cfg.MaxRequestSize)
+}
+
+func TestLoad_ExternalReadinessProbeConfiguration(t *testing.T) {
+	viper.Reset()
+	_ = os.Setenv("ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE", "http")
+	_ = os.Setenv("ECHO_APP_EXTERNAL_READINESS_PROBE_TARGET", "http://upstream/health")
+	_ = os.Setenv("ECHO_APP_EXTERNAL_READINESS_PROBE_INTERVAL", "5s")
+	_ = os.Setenv("ECHO_APP_EXTERNAL_READINESS_PROBE_TIMEOUT", "500ms")
+	_ = os.Setenv("ECHO_APP_EXTERNAL_READINESS_HTTP_METHOD", "HEAD")
+	_ = os.Setenv("ECHO_APP_EXTERNAL_READINESS_HTTP_EXPECTED_STATUS", "204")
+	defer func() {
+		_ = os.Unsetenv("ECHO_APP_EXTERNAL_READINESS_PROBE_TYPE")
+		_ = os.Unsetenv("ECHO_APP_EXTERNAL_READINESS_PROBE_TARGET")
+		_ = os.Unsetenv("ECHO_APP_EXTERNAL_READINESS_PROBE_INTERVAL")
+		_ = os.Unsetenv("ECHO_APP_EXTERNAL_READINESS_PROBE_TIMEOUT")
+		_ = os.Unsetenv("ECHO_APP_EXTERNAL_READINESS_HTTP_METHOD")
+		_ = os.Unsetenv("ECHO_APP_EXTERNAL_READINESS_HTTP_EXPECTED_STATUS")
+	}()
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "http", cfg.ExternalReadinessProbe.Type)
+	assert.Equal(t, "http://upstream/health", cfg.ExternalReadinessProbe.Target)
+	assert.Equal(t, 5*time.Second, cfg.ExternalReadinessProbe.Interval)
+	assert.Equal(t, 500*time.Millisecond, cfg.ExternalReadinessProbe.Timeout)
+	assert.Equal(t, "HEAD", cfg.ExternalReadinessProbe.HTTPMethod)
+	assert.Equal(t, 204, cfg.ExternalReadinessProbe.HTTPExpectedStatus)
 }

--- a/internal/config/health.go
+++ b/internal/config/health.go
@@ -1,0 +1,19 @@
+package config
+
+import "time"
+
+// ExternalReadinessProbe configures an optional background dependency check that
+// contributes to this application's readiness state.
+type ExternalReadinessProbe struct {
+	Type               string
+	Target             string
+	Interval           time.Duration
+	Timeout            time.Duration
+	HTTPMethod         string
+	HTTPExpectedStatus int
+}
+
+// Enabled reports whether an external readiness probe is configured.
+func (p ExternalReadinessProbe) Enabled() bool {
+	return p.Type != "" && p.Type != "none" && p.Target != ""
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,0 +1,172 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/PhilipSchmid/echo-app/internal/config"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	StatusHealthy   = "healthy"
+	StatusUnhealthy = "unhealthy"
+	StatusReady     = "ready"
+	StatusNotReady  = "not ready"
+)
+
+// Checker maintains cheap, cached health and readiness state for HTTP probes.
+type Checker struct {
+	mu          sync.RWMutex
+	healthy     bool
+	ready       bool
+	lastError   string
+	lastChecked time.Time
+	probe       config.ExternalReadinessProbe
+	client      *http.Client
+}
+
+// NewChecker creates a Checker. Without an external readiness probe the app is
+// considered ready as soon as the probe endpoint is reachable.
+func NewChecker(probe config.ExternalReadinessProbe) *Checker {
+	ready := !probe.Enabled()
+	return &Checker{
+		healthy: true,
+		ready:   ready,
+		probe:   probe,
+		client:  &http.Client{Timeout: probe.Timeout},
+	}
+}
+
+// Start begins the optional external readiness controller. It stores results in
+// memory so /ready never performs slow dependency I/O on the request path.
+func (c *Checker) Start(ctx context.Context) {
+	if !c.probe.Enabled() {
+		return
+	}
+	go c.run(ctx)
+}
+
+func (c *Checker) run(ctx context.Context) {
+	c.checkOnce(ctx)
+	ticker := time.NewTicker(c.probe.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			c.SetReady(false, "shutting down")
+			return
+		case <-ticker.C:
+			c.checkOnce(ctx)
+		}
+	}
+}
+
+func (c *Checker) checkOnce(parent context.Context) {
+	ctx, cancel := context.WithTimeout(parent, c.probe.Timeout)
+	defer cancel()
+	err := c.check(ctx)
+	if err != nil {
+		logrus.Warnf("external readiness check failed: %v", err)
+		c.SetReady(false, err.Error())
+		return
+	}
+	c.SetReady(true, "")
+}
+
+func (c *Checker) check(ctx context.Context) error {
+	switch strings.ToLower(c.probe.Type) {
+	case "http", "https":
+		return c.checkHTTP(ctx)
+	case "tcp":
+		return c.checkTCP(ctx)
+	case "ping", "icmp":
+		return c.checkPing(ctx)
+	default:
+		return fmt.Errorf("unsupported external readiness probe type %q", c.probe.Type)
+	}
+}
+
+func (c *Checker) checkHTTP(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, c.probe.HTTPMethod, c.probe.Target, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != c.probe.HTTPExpectedStatus {
+		return fmt.Errorf("expected HTTP status %d from %s, got %d", c.probe.HTTPExpectedStatus, c.probe.Target, resp.StatusCode)
+	}
+	return nil
+}
+
+func (c *Checker) checkTCP(ctx context.Context) error {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", c.probe.Target)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+func (c *Checker) checkPing(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "ping", "-c", "1", "-W", fmt.Sprintf("%d", int(c.probe.Timeout.Seconds())), c.probe.Target)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ping %s failed: %w: %s", c.probe.Target, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// SetHealthy updates the liveness state.
+func (c *Checker) SetHealthy(healthy bool, reason string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.healthy = healthy
+	c.lastError = reason
+	c.lastChecked = time.Now()
+}
+
+// SetReady updates the readiness state.
+func (c *Checker) SetReady(ready bool, reason string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ready = ready
+	c.lastError = reason
+	c.lastChecked = time.Now()
+}
+
+// HealthHandler returns 200 only while the app process considers itself live.
+func (c *Checker) HealthHandler(w http.ResponseWriter, _ *http.Request) {
+	c.mu.RLock()
+	healthy := c.healthy
+	reason := c.lastError
+	c.mu.RUnlock()
+	if !healthy {
+		http.Error(w, StatusUnhealthy+": "+reason, http.StatusServiceUnavailable)
+		return
+	}
+	_, _ = w.Write([]byte(StatusHealthy))
+}
+
+// ReadyHandler returns cached readiness without blocking on external checks.
+func (c *Checker) ReadyHandler(w http.ResponseWriter, _ *http.Request) {
+	c.mu.RLock()
+	ready := c.ready && c.healthy
+	reason := c.lastError
+	c.mu.RUnlock()
+	if !ready {
+		http.Error(w, StatusNotReady+": "+reason, http.StatusServiceUnavailable)
+		return
+	}
+	_, _ = w.Write([]byte(StatusReady))
+}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/PhilipSchmid/echo-app/internal/config"
+	probing "github.com/prometheus-community/pro-bing"
 	"github.com/sirupsen/logrus"
 )
 
@@ -30,17 +30,21 @@ type Checker struct {
 	lastChecked time.Time
 	probe       config.ExternalReadinessProbe
 	client      *http.Client
+	icmpProbe   icmpProbeFunc
 }
+
+type icmpProbeFunc func(context.Context, string, time.Duration) error
 
 // NewChecker creates a Checker. Without an external readiness probe the app is
 // considered ready as soon as the probe endpoint is reachable.
 func NewChecker(probe config.ExternalReadinessProbe) *Checker {
 	ready := !probe.Enabled()
 	return &Checker{
-		healthy: true,
-		ready:   ready,
-		probe:   probe,
-		client:  &http.Client{Timeout: probe.Timeout},
+		healthy:   true,
+		ready:     ready,
+		probe:     probe,
+		client:    &http.Client{Timeout: probe.Timeout},
+		icmpProbe: runICMPProbe,
 	}
 }
 
@@ -87,7 +91,7 @@ func (c *Checker) check(ctx context.Context) error {
 	case "tcp":
 		return c.checkTCP(ctx)
 	case "ping", "icmp":
-		return c.checkPing(ctx)
+		return c.checkICMP(ctx)
 	default:
 		return fmt.Errorf("unsupported external readiness probe type %q", c.probe.Type)
 	}
@@ -118,11 +122,26 @@ func (c *Checker) checkTCP(ctx context.Context) error {
 	return conn.Close()
 }
 
-func (c *Checker) checkPing(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "ping", "-c", "1", "-W", fmt.Sprintf("%d", int(c.probe.Timeout.Seconds())), c.probe.Target)
-	output, err := cmd.CombinedOutput()
+func (c *Checker) checkICMP(ctx context.Context) error {
+	return c.icmpProbe(ctx, c.probe.Target, c.probe.Timeout)
+}
+
+func runICMPProbe(ctx context.Context, target string, timeout time.Duration) error {
+	pinger, err := probing.NewPinger(target)
 	if err != nil {
-		return fmt.Errorf("ping %s failed: %w: %s", c.probe.Target, err, strings.TrimSpace(string(output)))
+		return fmt.Errorf("create ICMP readiness probe for %s: %w", target, err)
+	}
+	pinger.Count = 1
+	pinger.Timeout = timeout
+	pinger.ResolveTimeout = timeout
+	pinger.SetPrivileged(true)
+
+	if err := pinger.RunWithContext(ctx); err != nil {
+		return fmt.Errorf("ICMP readiness probe for %s failed: %w", target, err)
+	}
+	stats := pinger.Statistics()
+	if stats.PacketsRecv == 0 {
+		return fmt.Errorf("ICMP readiness probe for %s failed: no packets received", target)
 	}
 	return nil
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,0 +1,88 @@
+package health
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/PhilipSchmid/echo-app/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckerDefaultReady(t *testing.T) {
+	checker := NewChecker(config.ExternalReadinessProbe{})
+
+	ready := httptest.NewRecorder()
+	checker.ReadyHandler(ready, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	assert.Equal(t, http.StatusOK, ready.Code)
+	assert.Equal(t, StatusReady, ready.Body.String())
+
+	healthy := httptest.NewRecorder()
+	checker.HealthHandler(healthy, httptest.NewRequest(http.MethodGet, "/health", nil))
+	assert.Equal(t, http.StatusOK, healthy.Code)
+	assert.Equal(t, StatusHealthy, healthy.Body.String())
+}
+
+func TestCheckerReadinessTracksHTTPProbe(t *testing.T) {
+	upstreamReady := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-upstreamReady:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	}))
+	defer upstream.Close()
+
+	checker := NewChecker(config.ExternalReadinessProbe{
+		Type:               "http",
+		Target:             upstream.URL,
+		Interval:           10 * time.Millisecond,
+		Timeout:            time.Second,
+		HTTPMethod:         http.MethodGet,
+		HTTPExpectedStatus: http.StatusNoContent,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	checker.Start(ctx)
+
+	require.Eventually(t, func() bool { return readyStatus(checker) == http.StatusServiceUnavailable }, time.Second, 10*time.Millisecond)
+	close(upstreamReady)
+	require.Eventually(t, func() bool { return readyStatus(checker) == http.StatusOK }, time.Second, 10*time.Millisecond)
+}
+
+func TestCheckerTCPProbe(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			_ = conn.Close()
+		}
+	}()
+
+	checker := NewChecker(config.ExternalReadinessProbe{
+		Type:     "tcp",
+		Target:   listener.Addr().String(),
+		Interval: time.Second,
+		Timeout:  time.Second,
+	})
+	checker.checkOnce(context.Background())
+	assert.Equal(t, http.StatusOK, readyStatus(checker))
+}
+
+func readyStatus(checker *Checker) int {
+	w := httptest.NewRecorder()
+	checker.ReadyHandler(w, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	_, _ = io.Copy(io.Discard, w.Result().Body)
+	return w.Code
+}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -78,6 +79,44 @@ func TestCheckerTCPProbe(t *testing.T) {
 	})
 	checker.checkOnce(context.Background())
 	assert.Equal(t, http.StatusOK, readyStatus(checker))
+}
+
+func TestCheckerICMPProbe(t *testing.T) {
+	checker := NewChecker(config.ExternalReadinessProbe{
+		Type:     "icmp",
+		Target:   "192.0.2.1",
+		Interval: time.Second,
+		Timeout:  250 * time.Millisecond,
+	})
+	called := false
+	checker.icmpProbe = func(ctx context.Context, target string, timeout time.Duration) error {
+		called = true
+		assert.NoError(t, ctx.Err())
+		assert.Equal(t, "192.0.2.1", target)
+		assert.Equal(t, 250*time.Millisecond, timeout)
+		return nil
+	}
+
+	checker.checkOnce(context.Background())
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, readyStatus(checker))
+}
+
+func TestCheckerICMPProbeFailure(t *testing.T) {
+	checker := NewChecker(config.ExternalReadinessProbe{
+		Type:     "icmp",
+		Target:   "192.0.2.1",
+		Interval: time.Second,
+		Timeout:  time.Second,
+	})
+	checker.icmpProbe = func(context.Context, string, time.Duration) error {
+		return errors.New("icmp failed")
+	}
+
+	checker.checkOnce(context.Background())
+
+	assert.Equal(t, http.StatusServiceUnavailable, readyStatus(checker))
 }
 
 func readyStatus(checker *Checker) int {

--- a/internal/server/manager.go
+++ b/internal/server/manager.go
@@ -8,12 +8,14 @@ import (
 	"time"
 
 	"github.com/PhilipSchmid/echo-app/internal/config"
+	"github.com/PhilipSchmid/echo-app/internal/health"
 	"github.com/sirupsen/logrus"
 )
 
 // Manager manages all servers and handles graceful shutdown
 type Manager struct {
 	cfg      *config.Config
+	health   *health.Checker
 	servers  []Server
 	wg       sync.WaitGroup
 	shutdown chan struct{}
@@ -27,9 +29,10 @@ type Server interface {
 }
 
 // NewManager creates a new server manager
-func NewManager(cfg *config.Config) *Manager {
+func NewManager(cfg *config.Config, healthChecker *health.Checker) *Manager {
 	return &Manager{
 		cfg:      cfg,
+		health:   healthChecker,
 		servers:  make([]Server, 0),
 		shutdown: make(chan struct{}),
 	}
@@ -58,6 +61,9 @@ func (m *Manager) Start(ctx context.Context) error {
 
 // Shutdown gracefully shuts down all servers
 func (m *Manager) Shutdown(timeout time.Duration) error {
+	if m.health != nil {
+		m.health.SetReady(false, "shutting down")
+	}
 	close(m.shutdown)
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/internal/server/manager_test.go
+++ b/internal/server/manager_test.go
@@ -83,7 +83,7 @@ func (m *mockServer) Name() string {
 
 func TestNewManager(t *testing.T) {
 	cfg := &config.Config{}
-	manager := NewManager(cfg)
+	manager := NewManager(cfg, nil)
 
 	assert.NotNil(t, manager)
 	assert.Equal(t, cfg, manager.cfg)
@@ -94,7 +94,7 @@ func TestNewManager(t *testing.T) {
 
 func TestManager_RegisterServer(t *testing.T) {
 	cfg := &config.Config{}
-	manager := NewManager(cfg)
+	manager := NewManager(cfg, nil)
 
 	// Register first server
 	srv1 := newMockServer("server1")
@@ -113,7 +113,7 @@ func TestManager_RegisterServer(t *testing.T) {
 
 func TestManager_StartAndShutdown(t *testing.T) {
 	cfg := &config.Config{}
-	manager := NewManager(cfg)
+	manager := NewManager(cfg, nil)
 
 	// Create mock servers
 	srv1 := newMockServer("server1")
@@ -151,7 +151,7 @@ func TestManager_StartAndShutdown(t *testing.T) {
 
 func TestManager_ShutdownTimeout(t *testing.T) {
 	cfg := &config.Config{}
-	manager := NewManager(cfg)
+	manager := NewManager(cfg, nil)
 
 	// Create a mock server that takes too long to shut down
 	srv := newMockServer("slow-server")
@@ -185,7 +185,7 @@ func TestManager_ShutdownTimeout(t *testing.T) {
 
 func TestManager_ShutdownErrors(t *testing.T) {
 	cfg := &config.Config{}
-	manager := NewManager(cfg)
+	manager := NewManager(cfg, nil)
 
 	// Create mock servers with shutdown errors
 	srv1 := newMockServer("server1")
@@ -221,7 +221,7 @@ func TestManager_ShutdownErrors(t *testing.T) {
 
 func TestManager_Wait(t *testing.T) {
 	cfg := &config.Config{}
-	manager := NewManager(cfg)
+	manager := NewManager(cfg, nil)
 
 	// Create mock server that completes quickly
 	srv := newMockServer("server")
@@ -254,7 +254,7 @@ func TestManager_Wait(t *testing.T) {
 
 func TestManager_MultipleServers(t *testing.T) {
 	cfg := &config.Config{}
-	manager := NewManager(cfg)
+	manager := NewManager(cfg, nil)
 
 	// Create multiple mock servers
 	numServers := 5
@@ -295,7 +295,7 @@ func TestManager_MultipleServers(t *testing.T) {
 
 func TestManager_EmptyManager(t *testing.T) {
 	cfg := &config.Config{}
-	manager := NewManager(cfg)
+	manager := NewManager(cfg, nil)
 
 	// Start with no servers
 	ctx, cancel := context.WithCancel(context.Background())
@@ -314,7 +314,7 @@ func TestManager_EmptyManager(t *testing.T) {
 
 func TestManager_ShutdownBeforeStart(t *testing.T) {
 	cfg := &config.Config{}
-	manager := NewManager(cfg)
+	manager := NewManager(cfg, nil)
 
 	srv := newMockServer("server")
 	manager.RegisterServer(srv)
@@ -331,7 +331,7 @@ func TestManager_ShutdownBeforeStart(t *testing.T) {
 
 func TestManager_ConcurrentShutdown(t *testing.T) {
 	cfg := &config.Config{}
-	manager := NewManager(cfg)
+	manager := NewManager(cfg, nil)
 
 	// Create servers with different shutdown delays
 	srv1 := newMockServer("fast-server")

--- a/internal/server/metrics_server.go
+++ b/internal/server/metrics_server.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/PhilipSchmid/echo-app/internal/config"
+	"github.com/PhilipSchmid/echo-app/internal/health"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 )
@@ -16,13 +17,19 @@ type MetricsServer struct {
 	cfg        *config.Config
 	server     *http.Server
 	listenAddr string
+	health     *health.Checker
 }
 
 // NewMetricsServer creates a new metrics server
-func NewMetricsServer(cfg *config.Config) *MetricsServer {
+func NewMetricsServer(cfg *config.Config, healthChecker *health.Checker) *MetricsServer {
+	if healthChecker == nil {
+		healthChecker = health.NewChecker(config.ExternalReadinessProbe{})
+	}
+
 	return &MetricsServer{
 		cfg:        cfg,
 		listenAddr: ":" + cfg.MetricsPort,
+		health:     healthChecker,
 	}
 }
 
@@ -37,21 +44,10 @@ func (s *MetricsServer) Start(ctx context.Context) error {
 	// Wrap metrics handler with timeout to prevent hung scrapers
 	mux.Handle("/metrics", http.TimeoutHandler(promhttp.Handler(), 10*time.Second, "Metrics collection timeout"))
 
-	// Add health check endpoint
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte("OK")); err != nil {
-			logrus.Errorf("Failed to write health response: %v", err)
-		}
-	})
-
-	// Add readiness endpoint
-	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte("Ready")); err != nil {
-			logrus.Errorf("Failed to write readiness response: %v", err)
-		}
-	})
+	if s.health != nil {
+		mux.HandleFunc("/health", s.health.HealthHandler)
+		mux.HandleFunc("/ready", s.health.ReadyHandler)
+	}
 
 	s.server = &http.Server{
 		Addr:         s.listenAddr,

--- a/internal/server/metrics_server_test.go
+++ b/internal/server/metrics_server_test.go
@@ -18,7 +18,7 @@ func TestNewMetricsServer(t *testing.T) {
 		MetricsPort: "13000",
 	}
 
-	server := NewMetricsServer(cfg)
+	server := NewMetricsServer(cfg, nil)
 
 	assert.NotNil(t, server)
 	assert.Equal(t, cfg, server.cfg)
@@ -30,7 +30,7 @@ func TestMetricsServer_Name(t *testing.T) {
 		MetricsPort: "13001",
 	}
 
-	server := NewMetricsServer(cfg)
+	server := NewMetricsServer(cfg, nil)
 	assert.Equal(t, "Metrics", server.Name())
 }
 
@@ -39,7 +39,7 @@ func TestMetricsServer_StartAndShutdown(t *testing.T) {
 		MetricsPort: "13002",
 	}
 
-	server := NewMetricsServer(cfg)
+	server := NewMetricsServer(cfg, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -82,7 +82,7 @@ func TestMetricsServer_HealthEndpoint(t *testing.T) {
 		MetricsPort: "13003",
 	}
 
-	server := NewMetricsServer(cfg)
+	server := NewMetricsServer(cfg, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -99,7 +99,7 @@ func TestMetricsServer_HealthEndpoint(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Equal(t, "OK", string(body))
+	assert.Equal(t, "healthy", string(body))
 
 	// Shutdown
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -112,7 +112,7 @@ func TestMetricsServer_ReadyEndpoint(t *testing.T) {
 		MetricsPort: "13004",
 	}
 
-	server := NewMetricsServer(cfg)
+	server := NewMetricsServer(cfg, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -129,7 +129,7 @@ func TestMetricsServer_ReadyEndpoint(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Equal(t, "Ready", string(body))
+	assert.Equal(t, "ready", string(body))
 
 	// Shutdown
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -142,7 +142,7 @@ func TestMetricsServer_MetricsEndpoint(t *testing.T) {
 		MetricsPort: "13005",
 	}
 
-	server := NewMetricsServer(cfg)
+	server := NewMetricsServer(cfg, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -176,7 +176,7 @@ func TestMetricsServer_MetricsTimeout(t *testing.T) {
 		MetricsPort: "13006",
 	}
 
-	server := NewMetricsServer(cfg)
+	server := NewMetricsServer(cfg, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -211,7 +211,7 @@ func TestMetricsServer_ShutdownWithoutStart(t *testing.T) {
 		MetricsPort: "13007",
 	}
 
-	server := NewMetricsServer(cfg)
+	server := NewMetricsServer(cfg, nil)
 
 	// Shutdown without starting should not error
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -226,7 +226,7 @@ func TestMetricsServer_GracefulShutdown(t *testing.T) {
 		MetricsPort: "13008",
 	}
 
-	server := NewMetricsServer(cfg)
+	server := NewMetricsServer(cfg, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -263,7 +263,7 @@ func TestMetricsServer_MultipleEndpoints(t *testing.T) {
 		MetricsPort: "13009",
 	}
 
-	server := NewMetricsServer(cfg)
+	server := NewMetricsServer(cfg, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -282,13 +282,13 @@ func TestMetricsServer_MultipleEndpoints(t *testing.T) {
 			name:           "health endpoint",
 			endpoint:       "/health",
 			expectedStatus: http.StatusOK,
-			expectedBody:   "OK",
+			expectedBody:   "healthy",
 		},
 		{
 			name:           "ready endpoint",
 			endpoint:       "/ready",
 			expectedStatus: http.StatusOK,
-			expectedBody:   "Ready",
+			expectedBody:   "ready",
 		},
 		{
 			name:           "metrics endpoint",


### PR DESCRIPTION
### Motivation

- Add an optional background external readiness probe so the app can mark itself NotReady when an upstream dependency is unavailable. 
- Expose unified liveness and readiness endpoints on the metrics/admin listener and ensure readiness reflects the external probe state. 

### Description

- Introduce `ExternalReadinessProbe` in `internal/config` and wire new CLI flags and environment variables for probe type, target, interval, timeout, HTTP method and expected status. 
- Add a new `health.Checker` type in `internal/health` that runs background checks for `http`, `tcp`, and `ping`/`icmp` probes and exposes `HealthHandler` and `ReadyHandler`. 
- Integrate the health checker into `main` and `server.Manager` and hook the `/health` and `/ready` endpoints on the metrics server to use the checker. 
- Update README and examples to document the new env vars/flags and show usage; adjust tests and server behavior strings to use `healthy`/`ready` responses. 

### Testing

- Ran unit tests with `go test ./...` which include the new `TestLoad_ExternalReadinessProbeConfiguration` and `internal/health` tests, and all tests succeeded. 
- Updated `internal/server` and `internal/server/metrics_server_test.go` tests to account for health integration and they passed. 
- Existing manager and config tests were updated to accept the new constructor signatures and validations and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44c5da27cc832eb8869ef2da67562f)